### PR TITLE
y_hooks array parameter support

### DIFF
--- a/YSI_Core/y_als/impl.inc
+++ b/YSI_Core/y_als/impl.inc
@@ -275,11 +275,13 @@ enum ALS
 #define ALS_KS_string:%0[],     %0[],ALS_KS_
 #define ALS_KS_Float:%0,        Float:%0,ALS_KS_
 #define ALS_KS_tag:%3:%0,       %3:%0,ALS_KS_
+#define ALS_KS_array:%0[%1],    %0[%1],ALS_KS_
 #define ALS_KS_end:%0)          %0)
 #define ALS_KS_none:)           )
 #define ALS_KS_end_string:%0[]) %0[])
 #define ALS_KS_end_Float:%0)    Float:%0)
 #define ALS_KS_end_tag:%3:%0)   %3:%0)
+#define ALS_KS_end_array:%0[%1]) %0[%1])
 
 #define ALS_TS_more:%0,         %0,ALS_TS_
 #define ALS_TS_string:%0[],     (%0),ALS_TS_


### PR DESCRIPTION
#define ALS_DO_ArrayTest<%0> %0<ArrayTest,ia>(array:arr1[E_TEST_DATA], end_array:arr2[E_TEST_DATA])

enum E_TEST_DATA {
	E_DATA_INT,
	Float:E_DATA_FLOAT,
	E_DATA_STRING[32]
};

hook OnArrayTest(arr1[E_TEST_DATA], arr2[E_TEST_DATA]) {